### PR TITLE
Change `analytics` to `statistics`

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -219,21 +219,24 @@ function shouldShowBanner() {
   return false;
 }
 
-function setCookieSetting(type, form) {
-  const element = form.elements[`${type}-cookies`];
-
-  // If the element exists and is set to yes, set the setting to true
-  if (element !== undefined) {
-    setConsentSetting(type, element.value === 'yes');
-  }
-}
-
 // Set cookie settings from the preference form
 function setCookieSettings(form) {
-  setCookieSetting('analytics', form);
-  setCookieSetting('marketing', form);
-  setCookieSetting('preferences', form);
-  setConsentSetting('consented', true);
+  let element;
+
+  const settings = ['statistics', 'marketing', 'preferences'];
+  const consent = {
+    consented: true,
+  };
+
+  settings.forEach((setting) => {
+    element = form.elements[`${setting}-cookies`];
+
+    if (element !== undefined) {
+      consent[setting] = element.value === 'yes';
+    }
+  });
+
+  setConsent(consent);
 }
 
 /*

--- a/src/cookiesettings.js
+++ b/src/cookiesettings.js
@@ -1,6 +1,6 @@
 import settingsHtml from './html/settings.html';
 
-import analyticsSettings from './html/_analytics_settings.html';
+import statisticsSettings from './html/_statistics_settings.html';
 import marketingSettings from './html/_marketing_settings.html';
 import preferencesSettings from './html/_preferences_settings.html';
 
@@ -28,7 +28,7 @@ function applyDefault(key, form, consentSettings) {
 function applyDefaults(consentSettings) {
   const form = document['govuk-cookie-page_form'];
 
-  applyDefault('analytics', form, consentSettings);
+  applyDefault('statistics', form, consentSettings);
   applyDefault('marketing', form, consentSettings);
   applyDefault('preferences', form, consentSettings);
 }
@@ -42,13 +42,11 @@ function applyDefaults(consentSettings) {
 export default function insertCookieSettings(element, consentSettings) {
   const wrapper = element;
   const doc = document.implementation.createHTMLDocument('');
-  const settingsDiv = doc.createElement('div');
 
   doc.body.innerHTML = settingsHtml;
-  settingsDiv.innerHTML = analyticsSettings;
 
-  if (element.dataset.analytics !== undefined) {
-    appendSettings(doc, analyticsSettings);
+  if (element.dataset.statistics !== undefined) {
+    appendSettings(doc, statisticsSettings);
   }
 
   if (element.dataset.marketing !== undefined) {

--- a/src/html/_statistics_settings.html
+++ b/src/html/_statistics_settings.html
@@ -5,14 +5,14 @@
     </legend>
     <div class="govuk-radios">
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="analytics-cookies" name="analytics-cookies" type="radio" value="yes">
-        <label class="govuk-label govuk-radios__label" for="analytics-cookies">
+        <input class="govuk-radios__input" id="statistics-cookies" name="statistics-cookies" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="statistics-cookies">
           Yes
         </label>
       </div>
       <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="analytics-cookies-2" name="analytics-cookies" type="radio" value="no">
-        <label class="govuk-label govuk-radios__label" for="analytics-cookies-2">
+        <input class="govuk-radios__input" id="statistics-cookies-2" name="statistics-cookies" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="statistics-cookies-2">
           No
         </label>
       </div>

--- a/tests/example/cookie-settings.html
+++ b/tests/example/cookie-settings.html
@@ -65,7 +65,7 @@
         <h2 class="govuk-heading-l">Change your cookie settings</h2>
         <div
           id="govuk-cookie-preferences"
-          data-analytics
+          data-statistics
           data-marketing
           data-preferences
         >

--- a/tests/integration-tests/cookiesettings.test.js
+++ b/tests/integration-tests/cookiesettings.test.js
@@ -24,7 +24,7 @@ describe('Settings form is usable', () => {
   });
 
   it('should allow all settings to be set', async () => {
-    await page.click('#analytics-cookies');
+    await page.click('#statistics-cookies');
     await page.click('#marketing-cookies');
     await page.click('#preferences-cookies');
 
@@ -36,7 +36,7 @@ describe('Settings form is usable', () => {
 
     await expect(consentSettings.consented).toEqual(true);
 
-    await expect(consentSettings.analytics).toEqual(true);
+    await expect(consentSettings.statistics).toEqual(true);
     await expect(consentSettings.marketing).toEqual(true);
     await expect(consentSettings.preferences).toEqual(true);
   });
@@ -50,18 +50,22 @@ describe('setting and resetting values', () => {
     await loadPage();
   });
 
-  it('should allow analytics settings to be set', async () => {
-    await page.click('#analytics-cookies');
+  it('should allow statistics settings to be set', async () => {
+    await page.click('#statistics-cookies');
     await page.click('#govuk-cookie-page_save');
 
     await loadPage();
 
-    await page.click('#analytics-cookies-2');
+    // For some reason, not waiting causes the incorrect
+    // element to be clicked
+    await page.waitFor(1000);
+
+    await page.click('#statistics-cookies-2');
     await page.click('#govuk-cookie-page_save');
 
     consentSettings = await getConsentSettings();
 
-    await expect(consentSettings.analytics).toEqual(false);
+    await expect(consentSettings.statistics).toEqual(false);
   });
 
   it('should allow marketing settings to be set', async () => {
@@ -100,24 +104,24 @@ describe('default values', () => {
   });
 
   it('should set all radio buttons to "No" by default', async () => {
-    const analyticsValue = await page.evaluate(async () => document.querySelector('#analytics-cookies-2').checked);
+    const statisticsValue = await page.evaluate(async () => document.querySelector('#statistics-cookies-2').checked);
     const marketingValue = await page.evaluate(async () => document.querySelector('#marketing-cookies-2').checked);
     const preferencesValue = await page.evaluate(async () => document.querySelector('#preferences-cookies-2').checked);
 
-    expect(analyticsValue).toBe(true);
+    expect(statisticsValue).toBe(true);
     expect(marketingValue).toBe(true);
     expect(preferencesValue).toBe(true);
   });
 
-  it('should set the analytics options once they have been set', async () => {
-    await page.click('#analytics-cookies');
+  it('should set the statistics options once they have been set', async () => {
+    await page.click('#statistics-cookies');
     await page.click('#govuk-cookie-page_save');
 
     await loadPage();
 
-    const analyticsValue = await page.evaluate(async () => document.querySelector('#analytics-cookies').checked);
+    const statisticsValue = await page.evaluate(async () => document.querySelector('#statistics-cookies').checked);
 
-    expect(analyticsValue).toBe(true);
+    expect(statisticsValue).toBe(true);
   });
 
   it('should set the marketing options once they have been set', async () => {


### PR DESCRIPTION
We don't have an `analytics` permission type (this is `statistics`). Changing this caused an issue with the tests, so for some reason we have to make the browser wait before clicking our settings. This won't be an issue in real life, and I've already spent ages on this, so getting it good enough for now. 

I've also taken the opportunity to refactor how we set the cookies, so it's all done in one go, which came out during a debug.